### PR TITLE
add the ability to enable AMD GPUs

### DIFF
--- a/manifests/gres.pp
+++ b/manifests/gres.pp
@@ -31,7 +31,7 @@ define slurm::gres (
   $gres_name = $name,
   $type = undef,
   $node_name = undef,
-  Optional[Enum['nvml']] $auto_detect = undef,
+  Optional[Enum['nvml','rsmi']] $auto_detect = undef,
   $count = undef,
   $cores = undef,
   $file = undef,


### PR DESCRIPTION
I have verified and tested this change. This allows AMD GPUs to be enabled and autodetected on a compute node.