### PR TITLE
Bump MySQL and Systemd versions

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -42,7 +42,7 @@
     },
     {
       "name": "puppet/systemd",
-      "version_requirement": ">= 3.1.0 <4.0.0"
+      "version_requirement": ">= 3.1.0 <5.0.0"
     },
     {
       "name": "puppet/archive",

--- a/metadata.json
+++ b/metadata.json
@@ -22,7 +22,7 @@
     },
     {
       "name": "puppetlabs/mysql",
-      "version_requirement": ">=2.3.0 <13.0.0"
+      "version_requirement": ">=2.3.0 <14.0.0"
     },
     {
       "name": "puppet/epel",


### PR DESCRIPTION
Bump metadata to support newer versions of mysql and systemd modules. New versions don't break puppet6 yet but allow integration with more recent other modules.