### PR TITLE
allow slurmdbd_storage_port to be an empty string (support socket connection to DB)

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1085,7 +1085,7 @@ Default value: `'slurmdbd'`
 
 ##### <a name="-slurm--slurmdbd_storage_port"></a>`slurmdbd_storage_port`
 
-Data type: `Stdlib::Port`
+Data type: `Variant[Stdlib::Port, String[0,0]]`
 
 
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -337,7 +337,7 @@ class slurm (
   Stdlib::Host $slurmdbd_storage_host  = 'localhost',
   String[1] $slurmdbd_storage_loc   = 'slurm_acct_db',
   String[1] $slurmdbd_storage_pass  = 'slurmdbd',
-  Stdlib::Port $slurmdbd_storage_port  = 3306,
+  Variant[Stdlib::Port, String[0,0]] $slurmdbd_storage_port  = 3306,
   String[1] $slurmdbd_storage_type  = 'accounting_storage/mysql',
   String[1] $slurmdbd_storage_user  = 'slurmdbd',
   String[1] $slurmdbd_db_charset = 'utf8',

--- a/spec/shared_examples/slurm_slurmdbd_config.rb
+++ b/spec/shared_examples/slurm_slurmdbd_config.rb
@@ -74,6 +74,14 @@ shared_examples_for 'slurm::slurmdbd::config' do
     end
   end
 
+  context 'when slurmdbd_storage_port => ""' do
+    let(:param_override) { { slurmdbd_storage_port: '' } }
+
+    it 'overrides values' do
+      verify_contents(catalogue, 'slurmdbd.conf', ['StoragePort=""'])
+    end
+  end
+
   context 'when use_syslog => true' do
     let(:param_override) { { use_syslog: true } }
 

--- a/templates/slurmdbd/slurmdbd.conf.erb
+++ b/templates/slurmdbd/slurmdbd.conf.erb
@@ -13,6 +13,8 @@
 # <%= key %>
 <%- elsif value.is_a?(Array) -%>
 <%= key %>=<%= value.join(',') %>
+<%- elsif value == '' -%>
+<%= key %>=""
 <%- elsif value.is_a?(Hash) -%>
 <%- v = value.map {|k,v| "#{k}=#{v}" }.join(',') %>
 <%= key %>=<%= v %>


### PR DESCRIPTION
Allow slurmdbd_storage_port to be an empty string ("" or ''), which supports slurmdbd connecting to the DB via a socket rather than via TCP/IP.

Adjust the template for slurmdbd.conf so that if any value is an empty string (''), then put "" in as the value.

See https://github.com/treydock/puppet-slurm/issues/57 .