### PR TITLE
Allow munge_key_content to be provided as Binary type data

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -259,7 +259,7 @@ class slurm (
   # Munge key
   Boolean $manage_munge                 = false,
   Optional[String] $munge_key_source    = undef,
-  Optional[String] $munge_key_content   = undef,
+  Optional[Variant[String,Binary]] $munge_key_content   = undef,
 
   # Behavior overrides
   Boolean $manage_slurm_conf             = true,


### PR DESCRIPTION
Munge key is binary data, and should be serialised into the catalog as such. Passing the key content in as a string may cause catalog serialisation to fall back to PSON instead of JSON. When the catalog is serialised in PSON, binary data may be converted to base64, which leads to the encoded form of the secret being written to the key file on disk. If this happens, cluster authentication will fail due to nodes having different key file contents.

This change allows the key content to be passed in as Binary in addition to the previous allowed String.

Also requires: treydock/puppet-munge#23